### PR TITLE
Zbeacon unicast udp send/receive support

### DIFF
--- a/pyczmq/zbeacon.py
+++ b/pyczmq/zbeacon.py
@@ -52,11 +52,24 @@ def noecho(beacon):
     return C.zbeacon_noecho(beacon)
 
 
+@cdef('void zbeacon_unicast (zbeacon_t *self, int flag);')
+def unicast(beacon, flag):
+    """Start/stop listening on unicast packets
+    """
+    return C.zbeacon_unicast(beacon, flag)
+
+
+@cdef('void zbeacon_send (zbeacon_t *self,  char *ipaddress, void *transmit, size_t size);')
+def send(beacon, address, string):
+    """Send a frame directed to a particular unicast IP address once
+    """
+    return C.zbeacon_send(beacon, address, string, len(string))
+
+
 @cdef('void zbeacon_publish (zbeacon_t *self, void *transmit, size_t size);')
 def publish(beacon, string):
     """Start broadcasting beacon to peers at the specified interval"""
     return C.zbeacon_publish(beacon, string, len(string))
-
 
 @cdef('void zbeacon_silence (zbeacon_t *self);')
 def silence(beacon):

--- a/pyczmq/zsocket.py
+++ b/pyczmq/zsocket.py
@@ -212,7 +212,6 @@ int zsockopt_test (bool verbose);
 
 ipv6 = C.zsocket_ipv6
 ipv4only = C.zsocket_ipv4only
-probe_router = C.zsocket_probe_router
 plain_server = C.zsocket_plain_server
 plain_username = C.zsocket_plain_username
 plain_password = C.zsocket_plain_password

--- a/tests/test_zbeacon.py
+++ b/tests/test_zbeacon.py
@@ -26,5 +26,20 @@ def test_zbeacon():
     assert received_port == port_nbr
     zframe.destroy(content)
 
+    # turn on unicast rx/tx
+    zbeacon.unicast(client_beacon, 1)
+
+    # send unicast UDP message to ourselves
+    zbeacon.send (service_beacon, ipaddress, "SELF");
+
+    fromaddress = zstr.recv(beacon_socket)
+    assert(fromaddress == ipaddress)
+
+    content = zstr.recv(beacon_socket)
+    assert(content == "SELF")
+
+    # turn off unicast rx/tx
+    zbeacon.unicast(beacon_socket, 0)
+
     del service_beacon
     del ctx


### PR DESCRIPTION
this patch adds pyczmq bindings for:

//  Start/stop listening on unicast packets
void zbeacon_unicast (zbeacon_t *self,  int flag)

//  Send a frame directed to a particular IP unicast address once
void zbeacon_send (zbeacon_t *self,  char *ipaddress, byte *transmit, size_t size)

selftest example included.
